### PR TITLE
Fix FTBFS with "ld --as-needed". (Closes: Debian bug 641411)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(SRCS):
 	$(CC) $(CFLAGS) -c $*.c
 
 tcpser: $(OBJS)
-	$(CC) -g -o $@ $(OBJS) $(LDFLAGS)
+	$(CC) $(OBJS) $(LDFLAGS) -g -o $@
 
 depend: $(SRCS)
 	$(DEPEND) $(SRCS)


### PR DESCRIPTION
    - Thank you to Matthias Klose.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=641411