### PR TITLE
Mingw32 based native Windows Port

### DIFF
--- a/Makefile.mingw32
+++ b/Makefile.mingw32
@@ -1,0 +1,29 @@
+SRC=src
+SRCS = $(SRC)/bridge.c $(SRC)/debug.c $(SRC)/getcmd.c $(SRC)/ip.c $(SRC)/init.c $(SRC)/modem_core.c $(SRC)/nvt.c $(SRC)/serial.c $(SRC)/ip232.c $(SRC)/util.c $(SRC)/phone_book.c $(SRC)/tcpser.c $(SRC)/line.c $(SRC)/dce.c $(SRC)/mingw-termios.c
+OBJS = $(SRC)/bridge.o $(SRC)/debug.o $(SRC)/getcmd.o $(SRC)/ip.o $(SRC)/init.o $(SRC)/modem_core.o $(SRC)/nvt.o $(SRC)/serial.o $(SRC)/ip232.o $(SRC)/util.o $(SRC)/phone_book.o $(SRC)/tcpser.o $(SRC)/dce.o $(SRC)/line.o $(SRC)/mingw-termios.o
+CC ?= gcc
+DEF = -D_WIN32
+CFLAGS = -O $(DEF) -Wall
+LDFLAGS = -lpthread
+DEPEND = makedepend $(DEF) $(CFLAGS)
+
+all:	tcpser
+
+#.o.c:
+#	$(CC) $(CFLAGS) -c $*.c
+
+$(SRCS):
+	$(CC) $(CFLAGS) -c $*.c
+
+tcpser: $(OBJS)
+	$(CC) $(OBJS) $(LDFLAGS) -g -o $@
+
+depend: $(SRCS)
+	$(DEPEND) $(SRCS)
+
+clean:
+	$(RM) tcpser *.bak $(SRC)/*~ $(SRC)/*.o $(SRC)/*.bak core
+
+
+# DO NOT DELETE THIS LINE -- make depend depends on it.
+

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/socket.h>   // for recv...
+#endif
 #include <unistd.h>       // for read...
 #include <stdlib.h>       // for exit...
 #include <sys/param.h>

--- a/src/dce.c
+++ b/src/dce.c
@@ -21,9 +21,9 @@ int detect_parity (int charA, int charT) {
 
   if((parity == 1) || (parity == 2)) {
     if(parity == eobits)
-      return PARITY_EVEN;
+      return PAR_EVEN;
     else
-      return PARITY_ODD;
+      return PAR_ODD;
   } else
       return parity;
 }

--- a/src/dce.h
+++ b/src/dce.h
@@ -25,10 +25,10 @@
 #endif
 
 enum {
-  PARITY_SPACE_NONE = 0,
-  PARITY_ODD,
-  PARITY_EVEN,
-  PARITY_MARK
+  PAR_SPACE_ONE = 0,
+  PAR_ODD,
+  PAR_EVEN,
+  PAR_MARK
 };
 
 typedef struct dce_config {

--- a/src/ip.c
+++ b/src/ip.c
@@ -1,8 +1,13 @@
 #include <sys/types.h>
+#ifdef _WIN32
+#include <windows.h>
+typedef int socklen_t;
+#else
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#endif
 #include <unistd.h>       // for read...
 #include <stdlib.h>       // for atoi...
 

--- a/src/mingw-termios.c
+++ b/src/mingw-termios.c
@@ -1,0 +1,199 @@
+/* Replacement termios functions for MinGW32.  These versions of termios
+   functions serialize over a pipe to another process, which adjusts
+   the terminal.
+
+   Copyright (C) 2008 CodeSourcery, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <windows.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "mingw-termios.h"
+
+static HANDLE pipe_handle = INVALID_HANDLE_VALUE;
+static HANDLE pipe_mutex = INVALID_HANDLE_VALUE;
+
+static int
+link_to_wrapper (void)
+{
+  static int tried = 0;
+
+  if (!tried)
+    {
+      char pipe_name[256];
+
+      tried = 1;
+
+      /* Connect to the named pipe for communication with the wrapper.  */
+      sprintf (pipe_name, "\\\\.\\pipe\\gdb_wrapper_%ld",
+	       GetCurrentProcessId ());
+
+      pipe_handle = CreateFile (pipe_name,
+				GENERIC_READ | GENERIC_WRITE,
+				FILE_SHARE_READ | FILE_SHARE_WRITE,
+				NULL,
+				OPEN_EXISTING,
+				0,
+				NULL);
+      if (pipe_handle != INVALID_HANDLE_VALUE)
+	pipe_mutex = CreateMutex (NULL, TRUE, NULL);
+    }
+  else if (pipe_mutex != INVALID_HANDLE_VALUE)
+    WaitForSingleObject (pipe_mutex, INFINITE);
+
+  return (pipe_handle != INVALID_HANDLE_VALUE);
+}
+
+static int
+cygming_wrapper_cmd (const char *cmd, const void *args, int arglen, int *ret,
+		     char **retdata)
+{
+  if (link_to_wrapper ())
+    {
+      static char buf[4096] = {0};
+      int len = strlen (cmd) + 1;
+      DWORD read;
+      DWORD written;
+
+      memcpy (buf, cmd, len);
+      memcpy (buf + len, args, arglen);
+      //fprintf (stderr, "%.8lx writing to the wrapper\n", GetCurrentThreadId ());
+      if (!WriteFile (pipe_handle, buf, len + arglen, &written, NULL))
+	{
+	  fprintf (stderr, "error writting to cygming wrapper: %ld\n", GetLastError ());
+	  fflush (stderr);
+	  ReleaseMutex (pipe_mutex);
+	  return 0;
+	}
+
+      if (!ReadFile (pipe_handle, buf, sizeof (buf), &read, NULL))
+	{
+	  fprintf (stderr, "error waiting for cygming wrapper response: %ld",
+		   GetLastError ());
+	  fflush (stderr);
+	  ReleaseMutex (pipe_mutex);
+	  return 0;
+	}
+      //fprintf (stderr, "%.8lx finished read from the wrapper\n", GetCurrentThreadId ());
+
+      /* The returned value should be "OK" <number> ';' <bytes>.  */
+      if (memcmp (buf, "OK", 2) != 0)
+	{
+	  fprintf (stderr, "error: unexpected wrapper response: %s\n", buf);
+	  fflush (stderr);
+	  ReleaseMutex (pipe_mutex);
+	  return 0;
+	}
+
+      *ret = strtol (buf + 2, retdata, 0);
+      (*retdata)++;
+      ReleaseMutex (pipe_mutex);
+      return 1;
+    }
+  else
+    return 0;
+}
+
+int
+tcgetattr (int fd, struct termios *buf)
+{
+  int ret;
+  char *retdata;
+
+  if (cygming_wrapper_cmd ("tcgetattr", "", 0, &ret, &retdata))
+    {
+      if (ret == 0)
+	memcpy (buf, retdata, sizeof (*buf));
+      else
+	errno = EINVAL;
+      return ret;
+    }
+  else
+    {
+      memset (buf, 0, sizeof (*buf));
+      /* If FD is a TTY, readline will use getch for it, so we will
+	 must echo manually - getch does not echo.  If it is not a
+	 TTY, we must not echo since we have no way to disable the
+	 typical echo.  */
+      if (isatty (fd))
+	buf->c_lflag = ECHO;
+      return 0;
+    }
+}
+
+int
+tcsetattr (int fd, int actions, const struct termios *buf)
+{
+  int ret;
+  char *retdata;
+  if (cygming_wrapper_cmd ("tcsetattr", buf, sizeof (*buf), &ret, &retdata))
+    {
+      if (ret != 0)
+	errno = EINVAL;
+      return ret;
+    }
+  else
+    {
+      errno = EINVAL;
+      return -1;
+    }
+}
+
+int
+tcdrain (int fd)
+{
+  int ret;
+  char *retdata;
+  if (cygming_wrapper_cmd ("tcdrain", "", 0, &ret, &retdata))
+    {
+      if (ret != 0)
+	errno = EINVAL;
+      return ret;
+    }
+  else
+    {
+      errno = EINVAL;
+      return -1;
+    }
+}
+
+int
+tcflow (int fd, int action)
+{
+  errno = ENOTTY;
+  return -1;
+}
+
+int
+mingw_getwinsize (struct winsize *window_size)
+{
+  int ret;
+  char *retdata;
+  if (cygming_wrapper_cmd ("getwinsize", "", 0, &ret, &retdata))
+    {
+      if (ret == 0)
+	memcpy (window_size, retdata, sizeof (*window_size));
+      else
+	errno = EINVAL;
+      return ret;
+    }
+  else
+    {
+      errno = EINVAL;
+      return -1;
+    }
+}

--- a/src/mingw-termios.h
+++ b/src/mingw-termios.h
@@ -1,0 +1,131 @@
+/* Replacement termios.h for MinGW32.
+
+   Copyright (C) 2008 CodeSourcery, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef MINGW_TERMIOS_H
+#define MINGW_TERMIOS_H
+
+typedef unsigned char cc_t;
+typedef unsigned int tcflag_t;
+
+#define NCCS 18
+
+struct termios
+{
+  tcflag_t c_iflag;
+  tcflag_t c_oflag;
+  tcflag_t c_cflag;
+  tcflag_t c_lflag;
+  cc_t c_cc[NCCS];
+};
+
+#define VEOF 0
+#define VEOL 1
+#define VERASE 2
+#define VINTR 3
+#define VKILL 4
+#define VMIN 5
+#define VQUIT 6
+#define VSTART 7
+#define VSTOP 8
+#define VSUSP 9
+#define VTIME 10
+#define VEOL2 11
+#define VWERASE 12
+#define VREPRINT 13
+#define VLNEXT 15
+#define VDISCARD 16
+
+#define _POSIX_VDISABLE '\0'
+
+#define BRKINT 0x1
+#define ICRNL 0x2
+#define IGNBRK 0x4
+#define IGNCR 0x8
+#define IGNPAR 0x10
+#define INLCR 0x20
+#define INPCK 0x40
+#define ISTRIP 0x80
+#define IXANY 0x100
+#define IXOFF 0x200
+#define IXON 0x400
+#define PARMRK 0x800
+
+#define OPOST 0x1
+#define ONLCR 0x2
+#define OCRNL 0x4
+#define ONOCR 0x8
+#define ONLRET 0x10
+#define OFILL 0x20
+
+#define CSIZE 0x3
+#define CS5 0x0
+#define CS6 0x1
+#define CS7 0x2
+#define CS8 0x3
+#define CSTOPB 0x4
+#define CREAD 0x8
+#define PARENB 0x10
+#define PARODD 0x20
+#define HUPCL 0x40
+#define CLOCAL 0x80
+
+#define ECHO 0x1
+#define ECHOE 0x2
+#define ECHOK 0x4
+#define ECHONL 0x8
+#define ICANON 0x10
+#define IEXTEN 0x20
+#define ISIG 0x40
+#define NOFLSH 0x80
+#define TOSTOP 0x100
+#define FLUSHO 0x200
+
+#define TCSANOW 0
+#define TCSADRAIN 1
+#define TCSAFLUSH 2
+
+#define TCIOFF 0
+#define TCION 1
+#define TCOOFF 2
+#define TCOON 3
+
+int tcgetattr (int fd, struct termios *buf);
+int tcsetattr (int fd, int actions, const struct termios *buf);
+int tcdrain (int fd);
+int tcflow (int fd, int action);
+
+/* We want to intercept TIOCGWINSZ, but not FIONREAD.  No need to forward
+   TIOCSWINSZ; readline only uses it to suspend if in the background.
+   Readline doesn't make any other ioctl calls on mingw.  */
+
+#include <winsock.h>
+
+struct winsize
+{
+  unsigned short ws_row;
+  unsigned short ws_col;
+};
+
+int mingw_getwinsize (struct winsize *window_size);
+#define TIOCGWINSZ 0x42424240
+#define TIOCSWINSZ 0x42424241
+#define ioctl(fd, op, arg)				\
+  (((op) == TIOCGWINSZ) ? mingw_getwinsize (arg)	\
+   : ((op) == TIOCSWINSZ) ? -1				\
+   : ioctlsocket (fd, op, arg))
+
+#endif /* MINGW_TERMIOS_H */

--- a/src/serial.c
+++ b/src/serial.c
@@ -1,9 +1,16 @@
 #include <sys/file.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <windows.h>
+#include "mingw-termios.h"
+#define O_NOCTTY 0
+#define O_NONBLOCK 0
+#else
 #include <termios.h>
+#include <sys/ioctl.h>
+#endif
 #include <stdio.h>
 #include <fcntl.h>
-#include <sys/ioctl.h>
 #include "dce.h"
 #include "debug.h"
 


### PR DESCRIPTION
Since cygwin is really the worst of all options... i gave it a quick try to compile in msys2. Oh well, there is still some work to do - serial.c needs more love, and perhaps some windows specific code in ifdefs. I think i fixed everything else though.

I am making this PR in case someone might want to pick it up. This is NOT ready for merging, it will not even compile.

If that is even wanted, i could make a quick hack that removes support of real serial ports (when _WIN32 is defined), which would result in a native .exe that would at least work as a bridge to VICE (which may or may not work better than the cygwin based one, i dont know)