### PR TITLE
fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRC=src
 SRCS = $(SRC)/bridge.c $(SRC)/debug.c $(SRC)/getcmd.c $(SRC)/ip.c $(SRC)/init.c $(SRC)/modem_core.c $(SRC)/nvt.c $(SRC)/serial.c $(SRC)/ip232.c $(SRC)/util.c $(SRC)/phone_book.c $(SRC)/tcpser.c $(SRC)/line.c $(SRC)/dce.c
 OBJS = $(SRC)/bridge.o $(SRC)/debug.o $(SRC)/getcmd.o $(SRC)/ip.o $(SRC)/init.o $(SRC)/modem_core.o $(SRC)/nvt.o $(SRC)/serial.o $(SRC)/ip232.o $(SRC)/util.o $(SRC)/phone_book.o $(SRC)/tcpser.o $(SRC)/dce.o $(SRC)/line.o
-CC = gcc
+CC ?= gcc
 DEF = 
 CFLAGS = -O $(DEF) -Wall
 LDFLAGS = -lpthread
@@ -22,7 +22,7 @@ depend: $(SRCS)
 	$(DEPEND) $(SRCS)
 
 clean:
-	-rm tcpser *.bak $(SRC)/*~ $(SRC)/*.o $(SRC)/*.bak core
+	$(RM) tcpser *.bak $(SRC)/*~ $(SRC)/*.o $(SRC)/*.bak core
 
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.


### PR DESCRIPTION
This does two things:
- use $(RM) in the clean target, that makes it always work and it doesn't output error messages
- use CC ?= so you can override CC using sth like ```CC=mygcc make```